### PR TITLE
Don't show an error every time when schema.graphql can't be found

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ intellij {
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin

--- a/src/main/kotlin/io/smallrye/graphql/clientplugin/Schema.kt
+++ b/src/main/kotlin/io/smallrye/graphql/clientplugin/Schema.kt
@@ -51,20 +51,22 @@ internal class Schema {
     }
 
     private fun schema(): TypeDefinitionRegistry? {
-        val activeProject = ProjectUtil.getActiveProject() ?: return emptyBecause("no active project")
-        val basePath = activeProject.basePath ?: return emptyBecause("no base path in project " + activeProject.name)
+        val activeProject = ProjectUtil.getActiveProject() ?: return emptyBecause("no active project", true)
+        val basePath = activeProject.basePath ?: return emptyBecause("no base path in project " + activeProject.name, true)
         val path = Paths.get(basePath).resolve("schema.graphql")
-        return if (!Files.exists(path)) emptyBecause("no GraphQL schema found at $path")
+        return if (!Files.exists(path)) emptyBecause("no GraphQL schema found at $path", false)
         else try {
             parse(path)
         } catch (e: RuntimeException) {
-            emptyBecause("parsing of schema at $path failed:\n${e.message}")
+            emptyBecause("parsing of schema at $path failed:\n${e.message}", true)
         }
     }
 
-    private fun emptyBecause(message: String): TypeDefinitionRegistry? {
+    private fun emptyBecause(message: String, showAsError: Boolean): TypeDefinitionRegistry? {
         debug(message)
-        errors!!.accept(message)
+        if(showAsError) {
+            errors!!.accept(message)
+        }
         return null
     }
 


### PR DESCRIPTION
Right now, it shows an error in the UI every time you trigger autocompletion logic in a project that contains a `@GraphQLClientApi` interface, but no `ROOT/schema.graphql`, which is annoying.